### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "gulp-svgstore": "^6.1.0",
     "gulp-uglify": "^3.0.0",
     "gulp-webp": "^3.0.0",
-    "gulp-svg-sprite": "^1.5.0",
     "lost": "^8.3.1",
     "postcss-easing-gradients": "^3.0.1",
     "posthtml-include": "^1.1.0",
@@ -63,7 +62,6 @@
   },
   "dependencies": {
     "gulp-imagemin": "^4.1.0",
-    "npm": "^6.4.1",
     "slick-carousel": "^1.8.1"
   }
 }


### PR DESCRIPTION

Hello romanzemerov!

It seems like you have npm as one of your (dev-) dependency in lfa_news.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
